### PR TITLE
Tighten the className property on custom renderer props in TS declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,10 @@
 import { Component, CSSProperties, SFC } from "react";
 
+/**
+ * Props passed to custom renderers by `Scrollbar`.
+ */
 export interface ScrollbarRendererProps {
-    className?: string | string[];
+    className: string;
     style?: CSSProperties;
 }
 


### PR DESCRIPTION
This is the followup from the comment on #8. It's a very minor improvement, but should now allow directly passing native components to the render function with no wrapper lambda.