### PR TITLE
Clamp thumb position to avoid leaving track on Apple browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import PropTypes                         from "prop-types";
-import React                             from "react";
-import { getInnerHeight, getInnerWidth } from "./util/getInnerSizes";
-import LoopController                    from "./util/LoopController";
-import { getScrollbarWidth, isset }      from "./util/utilities";
+import PropTypes                            from "prop-types";
+import React                                from "react";
+import { getInnerHeight, getInnerWidth }    from "./util/getInnerSizes";
+import LoopController                       from "./util/LoopController";
+import { clamp, getScrollbarWidth, isset }  from "./util/utilities";
 
 function divRenderer(props) {
     return <div { ...props } />;
@@ -565,7 +565,7 @@ export default class Scrollbar extends React.Component
             const trackVerticalInnerHeight = getInnerHeight(this.trackVertical);
             const thumbVerticalHeight = this.computeThumbVerticalHeight(trackVerticalInnerHeight);
             const thumbVerticalOffset = thumbVerticalHeight
-                                        ? this.content.scrollTop / (this.content.scrollHeight - this.content.clientHeight) * (trackVerticalInnerHeight - thumbVerticalHeight)
+                                        ? clamp(0, this.content.scrollTop / (this.content.scrollHeight - this.content.clientHeight), 1) * (trackVerticalInnerHeight - thumbVerticalHeight)
                                         : 0;
 
             this.thumbVertical.style.transform = `translateY(${thumbVerticalOffset}px)`;
@@ -580,7 +580,7 @@ export default class Scrollbar extends React.Component
             const trackHorizontalInnerWidth = getInnerWidth(this.trackHorizontal);
             const thumbHorizontalWidth = this.computeThumbHorizontalWidth(trackHorizontalInnerWidth);
             let thumbHorizontalOffset = thumbHorizontalWidth
-                                        ? this.content.scrollLeft / (this.content.scrollWidth - this.content.clientWidth) * (trackHorizontalInnerWidth - thumbHorizontalWidth)
+                                        ? clamp(0, this.content.scrollLeft / (this.content.scrollWidth - this.content.clientWidth), 1) * (trackHorizontalInnerWidth - thumbHorizontalWidth)
                                         : 0;
 
             if (this.isRtl) {

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -27,3 +27,16 @@ export function getScrollbarWidth() {
 
     return scrollbarWidth;
 }
+
+/**
+ * Limit a number to fall in a specified range.
+ *
+ * @param {number} min The smallest allowed value
+ * @param {number} value The value to clamp
+ * @param {number} max The largest allowed value
+ *
+ * @returns {number} The clamped value.
+ */
+export function clamp(min, value, max) {
+    return Math.max(min, Math.min(value, max));
+}

--- a/tests/utilities.spec.js
+++ b/tests/utilities.spec.js
@@ -43,4 +43,18 @@ describe("utilities", () => {
                expect(sbWidth === 17 || sbWidth === 15).toBeTruthy();
            });
     });
+
+    describe("clamp", () => {
+        it("allows valid values", () => {
+            expect(clamp(0, 0.5, 1)).toBe(0.5);
+        });
+
+        it("applies a minimum", () => {
+            expect(clamp(0, -2, 1)).toBe(0);
+        });
+
+        it("applies a maximum", () => {
+            expect(clamp(0, 1.02, 1)).toBe(1);
+        })
+    })
 });


### PR DESCRIPTION
Enabling momentum scrolling causes Safari to report scrollTop/scrollLeft
values that are beyond the bounds of the content.
This change clamps to make sure those values can't pull the thumb out of the track.

Fixes #10