### PR TITLE
do not use isset to check for variables that might not exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -126,7 +126,7 @@ function (_React$Component) {
       var noScrollYChanged = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
       var noScrollXChanged = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
-      if (!(0, _utilities.isset)(document) || !_this.content) {
+      if (typeof document === "undefined" || !_this.content) {
         return _assertThisInitialized(_assertThisInitialized(_this));
       }
 
@@ -175,7 +175,7 @@ function (_React$Component) {
     });
 
     _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "removeListeners", function () {
-      if (!(0, _utilities.isset)(document) || !_this.content) {
+      if (typeof document === "undefined" || !_this.content) {
         return _assertThisInitialized(_assertThisInitialized(_this));
       }
 

--- a/dist/util/utilities.js
+++ b/dist/util/utilities.js
@@ -26,7 +26,7 @@ function getScrollbarWidth() {
     return scrollbarWidth;
   }
 
-  if (!isset(document)) {
+  if (typeof document === "undefined") {
     return scrollbarWidth = 0;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -376,7 +376,7 @@ export default class Scrollbar extends React.Component {
      * @return {Scrollbar}
      */
     addListeners = (noScrollChanged = false, noScrollYChanged = false, noScrollXChanged = false) => {
-        if (!isset(document) || !this.content) {
+        if (typeof document === "undefined" || !this.content) {
             return this;
         }
 
@@ -419,7 +419,7 @@ export default class Scrollbar extends React.Component {
      * @return {Scrollbar}
      */
     removeListeners = () => {
-        if (!isset(document) || !this.content) {
+        if (typeof document === "undefined" || !this.content) {
             return this;
         }
 

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -18,7 +18,7 @@ export function getScrollbarWidth() {
         return scrollbarWidth;
     }
 
-    if (!isset(document)) {
+    if (typeof document === "undefined") {
         return (scrollbarWidth = 0);
     }
 


### PR DESCRIPTION
isset cannot be used for variables that might not exist
because that results in a fatal error (e.g. `isset(document)` on Node.js)