### PR TITLE
v4.0.0-alpha.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "url": "https://github.com/xobotyi/react-scrollbars-custom/issues"
   },
   "homepage": "https://github.com/xobotyi/react-scrollbars-custom",
-  "author": "Anton Zinovyev",
+  "author": {
+    "name": "Anton Zinovyev",
+    "url": "https://github.com/xobotyi",
+    "email": "xog3@yandex.ru"
+  },
   "license": "MIT",
   "keywords": [
     "customizable",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-scrollbars-custom",
   "description": "The best React custom scrollbars component",
-  "version": "4.0.0-alpha.18",
+  "version": "4.0.0-alpha.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/xobotyi/react-scrollbars-custom.git"

--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -316,6 +316,15 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       } as React.CSSProperties,
       content: {
         ...(useDefaultStyles && defaultStyle.content),
+        ...(useDefaultStyles &&
+          !(
+            props.translateContentSizesToHolder ||
+            props.translateContentSizeYToHolder ||
+            props.translateContentSizeXToHolder
+          ) && {
+            minHeight: "100%",
+            minWidth: "100%"
+          }),
         ...props.contentProps!.style
       } as React.CSSProperties,
       scroller: {
@@ -355,7 +364,7 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       trackY: {
         ...(useDefaultStyles && defaultStyle.track.common),
         ...(useDefaultStyles && defaultStyle.track.y),
-        [state.isRTL ? "left" : "right"]: 0,
+        ...(useDefaultStyles && { [state.isRTL ? "left" : "right"]: 0 }),
         ...props.trackYProps!.style,
         ...(!state.trackYVisible && { display: "none" })
       } as React.CSSProperties,

--- a/src/style.ts
+++ b/src/style.ts
@@ -16,8 +16,8 @@ export const style = {
   } as React.CSSProperties,
 
   content: {
-    display: "inline-block",
-    verticalAlign: "bottom"
+    padding: 0.05, // needed to disable margin collapsing without flexboxes, other possible solutions here: https://stackoverflow.com/questions/19718634/how-to-disable-margin-collapsing
+    boxSizing: "border-box"
   } as React.CSSProperties,
 
   track: {


### PR DESCRIPTION
Content element now has the minheight & minWidth styles if content sizes translation is off (Fix: #65 );
Vertical scrollbar now has no hard stick to any side;