### PR TITLE
 v4.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.0.10
+
+- Refusing `is-fun` due to too big performance impact - no sense to use it with hte prop-types =\
+- Refusing `is-number` for almost the same reasons;
+
 ## v4.0.9
 
 - ESM version now has ESNext lang level;

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
   },
   "dependencies": {
     "cnbuilder": "^1.1.1",
-    "is-fun": "^1.0.4",
-    "is-number": "^7.0.0",
     "react-draggable": "^3.3.0",
     "zoom-level": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-scrollbars-custom",
   "description": "The best React custom scrollbars component",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/xobotyi/react-scrollbars-custom.git"

--- a/src/Emittr.ts
+++ b/src/Emittr.ts
@@ -1,6 +1,4 @@
-import isNum from "is-number";
-import isFun from "is-fun";
-import { isUndef } from "./util";
+import { isFun, isNum, isUndef } from "./util";
 
 type EventHandler = (...args: any[]) => void;
 type OnceHandlerState = {

--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -13,13 +13,11 @@ import cnb from "cnbuilder";
 import ScrollbarTrack, { ScrollbarTrackClickParameters, ScrollbarTrackProps } from "./ScrollbarTrack";
 import ScrollbarThumb, { ScrollbarThumbProps } from "./ScrollbarThumb";
 import * as util from "./util";
-import { getScrollbarWidth, isUndef } from "./util";
+import { getScrollbarWidth, isFun, isNum, isUndef } from "./util";
 import { DraggableData } from "react-draggable";
 import Emittr from "./Emittr";
 import defaultStyle from "./style";
 import { zoomLevel } from "zoom-level";
-import isNum from "is-number";
-import isFun from "is-fun";
 
 declare var global: {
   window?: Window;

--- a/src/ScrollbarThumb.tsx
+++ b/src/ScrollbarThumb.tsx
@@ -8,8 +8,7 @@ import {
   ElementPropsWithElementRefAndRenderer,
   renderDivWithRenderer
 } from "./common";
-import isFun from "is-fun";
-import { isUndef } from "./util";
+import { isFun, isUndef } from "./util";
 
 declare var global: {
   document?: Document;

--- a/src/ScrollbarTrack.tsx
+++ b/src/ScrollbarTrack.tsx
@@ -7,8 +7,7 @@ import {
   ElementPropsWithElementRefAndRenderer,
   renderDivWithRenderer
 } from "./common";
-import isFun from "is-fun";
-import { isUndef } from "./util";
+import { isFun, isUndef } from "./util";
 
 export interface ScrollbarTrackClickParameters {
   axis: AXIS_DIRECTION;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,3 @@
-import isNum from "is-number";
-
 declare var global: {
   document?: Document;
 };
@@ -7,6 +5,14 @@ let doc: Document | null = global.document || null;
 
 export function isUndef(v: any): boolean {
   return typeof v === "undefined";
+}
+
+export function isFun(v: any): boolean {
+  return typeof v === "function";
+}
+
+export function isNum(v: any): boolean {
+  return typeof v === "number";
 }
 
 /**


### PR DESCRIPTION
- Refusing `is-fun` due to too big performance impact - no sense to use it with hte prop-types =\
- Refusing `is-number` for almost the same reasons;