### PR TITLE
v4.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v4.0.11
+
+- A bit tweaked distribution strategy:
+  - `main` field of `package.json` is pointing to transpiled ES3-compatible version with CJS modules resolution;
+  - `module` field is pointing to transpiled ES3-compatible version with ES modules resolution;
+  - `esnext` field is pointing to the ES6+ version with ES modules resolution;
+
 ## v4.0.10
 
 - Refusing `is-fun` due to too big performance impact - no sense to use it with hte prop-types =\

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ npm install react-scrollbars-custom
 yarn add react-scrollbars-custom
 ```
 
+**INSTALLATION NOTE:**  
+This lib is written in ES6+ and delivering with both, transpiled and untranspiled versions:
+
+- `main` field of `package.json` is pointing to transpiled ES3-compatible version with CJS modules resolution;
+- `module` field is pointing to transpiled ES3-compatible version with ES modules resolution;
+- `esnext` field is pointing to the ES6+ version with ES modules resolution;
+
+Depending on your targets you may have to use [Webpack](https://webpack.js.org/) and/or
+[Babel](http://babeljs.io/) to pull untranspiled version of package.  
+See some tips on wiring thing up: [https://2ality.com/2017/06/pkg-esnext.html](https://2ality.com/2017/06/pkg-esnext.html)
+
 ## USAGE
 
 Underneath `react-scrollbars-custom` uses `requestAnimationFrame` loop, which check and update each known scrollbar, and as result - scrollbars updates synchronised with browser's render flow.

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "component",
     "custom"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/rsc.js",
+  "module": "dist/rsc.mjs",
+  "esnext": "dist/rsc.next.mjs",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist"
@@ -36,9 +37,9 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "cnbuilder": "^1.1.1",
+    "cnbuilder": "^1.1.4",
     "react-draggable": "^3.3.0",
-    "zoom-level": "^1.2.1"
+    "zoom-level": "^1.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-scrollbars-custom",
   "description": "The best React custom scrollbars component",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/xobotyi/react-scrollbars-custom.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,14 +8,47 @@ const externalDependencies = Array.from(new Set(ownKeys(pkg.peerDependencies).co
 export default [
   {
     input: "./src/index.ts",
+    external: externalDependencies,
+
+    output: [
+      {
+        file: pkg.esnext,
+        format: "es"
+      }
+    ],
+
+    plugins: [
+      ts({
+        clean: true,
+        useTsconfigDeclarationDir: true,
+        tsconfigOverride: {
+          compilerOptions: {
+            module: "esnext",
+            target: "esnext",
+            declaration: true,
+            declarationDir: __dirname + "/dist/types"
+          }
+        }
+      })
+    ]
+  },
+  {
+    input: "./src/index.ts",
+    external: externalDependencies,
+
     output: [
       {
         file: pkg.main,
         format: "cjs",
+        sourcemap: true,
         exports: "named"
+      },
+      {
+        file: pkg.module,
+        format: "esm"
       }
     ],
-    external: externalDependencies,
+
     plugins: [
       ts({
         clean: true,
@@ -41,30 +74,6 @@ export default [
             }
           ]
         ]
-      })
-    ]
-  },
-  {
-    input: "./src/index.ts",
-    output: [
-      {
-        file: pkg.module,
-        format: "esm"
-      }
-    ],
-    external: externalDependencies,
-    plugins: [
-      ts({
-        clean: true,
-        useTsconfigDeclarationDir: true,
-        tsconfigOverride: {
-          compilerOptions: {
-            module: "esnext",
-            target: "esnext",
-            declaration: true,
-            declarationDir: __dirname + "/dist/types"
-          }
-        }
       })
     ]
   }


### PR DESCRIPTION
- A bit tweaked distribution strategy:
  - `main` field of `package.json` is pointing to transpiled ES3-compatible version with CJS modules resolution;
  - `module` field is pointing to transpiled ES3-compatible version with ES modules resolution;
  - `esnext` field is pointing to the ES6+ version with ES modules resolution;