### PR TITLE
fix check for elementRef in render function

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -36,7 +36,7 @@ export function renderDivWithRenderer(props: ElementPropsWithElementRefAndRender
     return renderer(props);
   }
 
-  props.elementRef && delete props.elementRef;
+  delete props.elementRef;
 
   return <div {...props} ref={elementRef} />;
 }

--- a/tests/util.spec.ts
+++ b/tests/util.spec.ts
@@ -10,6 +10,7 @@ import {
   getInnerHeight,
   getInnerWidth,
   getScrollbarWidth,
+  renderDivWithRenderer,
   shouldReverseRTLScroll,
   uuid
 } from "../src/util";
@@ -576,6 +577,14 @@ describe("util", () => {
         expect(() => _dbgSetScrollbarWidth(undefined)).toThrow(
           new TypeError("override value expected to be a number or null, got undefined")
         );
+      });
+    });
+
+    describe("renderDivWithRenderer()", () => {
+      it("does not add elementRef prop", () => {
+        let result = renderDivWithRenderer({ elementRef: null, tabIndex: -1 }, null);
+        expect(result.props.elementRef).toBeUndefined();
+        expect(result.props.tabIndex).toBeDefined();
       });
     });
 


### PR DESCRIPTION
addresses #106 

determined that `props.elementRef` was coming through as `undefined` and was being passed onto the div. i don't think the check is necessary before deleting `props.elementRef`.