### PR TITLE
preventDefault for mouseDown events on thumbs

### DIFF
--- a/src/ScrollbarThumb.tsx
+++ b/src/ScrollbarThumb.tsx
@@ -154,6 +154,7 @@ export default class ScrollbarThumb extends React.Component<ScrollbarThumbProps,
       return;
     }
 
+    ev.preventDefault();
     ev.stopPropagation();
 
     if (!isUndef(ev.offsetX)) {


### PR DESCRIPTION
Fixes #112 

This allows focused elements not to loose focus when the scrollbar is dragged.
