### PR TITLE
Support onDragEnd method

### DIFF
--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -1227,7 +1227,7 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
     this.scrollLeft += ev.deltaX;
   };
 
-  private handleThumbXDrag = (data: DraggableData): void => {
+  private handleThumbXDrag = (data: DraggableData, isEnd: boolean = false): void => {
     if (
       !this.trackXElement ||
       !this.thumbXElement ||
@@ -1259,9 +1259,13 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       thumbSize,
       offset
     );
+
+    if (isEnd && this.props.thumbXProps && this.props.thumbXProps.onDragEnd) {
+      this.props.thumbXProps.onDragEnd(data, true);
+    }
   };
 
-  private handleThumbYDrag = (data: DraggableData): void => {
+  private handleThumbYDrag = (data: DraggableData, isEnd: boolean = false): void => {
     if (
       !this.scrollerElement ||
       !this.trackYElement ||
@@ -1290,6 +1294,9 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       thumbSize,
       offset
     );
+    if (isEnd && this.props.thumbYProps && this.props.thumbYProps.onDragEnd) {
+      this.props.thumbYProps.onDragEnd(data, true);
+    }
   };
 
   private handleScrollerScroll = () => {

--- a/src/ScrollbarThumb.tsx
+++ b/src/ScrollbarThumb.tsx
@@ -11,12 +11,15 @@ declare var global: {
 
 export type DragCallbackData = Pick<DraggableData, Exclude<keyof DraggableData, "node">>;
 
-export type ScrollbarThumbProps = ElementPropsWithElementRefAndRenderer & {
+export type ScrollbarThumbProps = Pick<
+  ElementPropsWithElementRefAndRenderer,
+  Exclude<keyof ElementPropsWithElementRefAndRenderer, "onDragEnd">
+> & {
   axis: AXIS_DIRECTION;
 
-  onDrag?: (data: DragCallbackData) => void;
+  onDrag?: (data: DragCallbackData, isEnd: boolean) => void;
   onDragStart?: (data: DragCallbackData) => void;
-  onDragEnd?: (data: DragCallbackData) => void;
+  onDragEnd?: (data: DragCallbackData, isEnd: boolean) => void;
 
   ref?: (ref: ScrollbarThumb | null) => void;
 };
@@ -109,7 +112,8 @@ export default class ScrollbarThumb extends React.Component<ScrollbarThumbProps,
           lastY: data.lastY - this.initialOffsetY,
           deltaX: data.deltaX,
           deltaY: data.deltaY
-        })
+        }),
+        false
       );
   };
 
@@ -125,7 +129,7 @@ export default class ScrollbarThumb extends React.Component<ScrollbarThumbProps,
         }
       : this.lastDragData;
 
-    this.props.onDragEnd && this.props.onDragEnd(resultData);
+    this.props.onDragEnd && this.props.onDragEnd(resultData, true);
 
     this.element && this.element.classList.remove("dragging");
 


### PR DESCRIPTION
The purpose of this PR is to notify when dragging of the thumb ends:
It includes:
- Call onDragEnd if provided by the user
- ScrollbarThumb types update