### PR TITLE
Allow set onDragEnd on thumbXProps and thumbYProps

### DIFF
--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -916,7 +916,7 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
         style: styles.thumbY,
         elementRef: this.elementRefThumbY,
         onDrag: this.handleThumbYDrag,
-        onDragEnd: this.handleThumbYDrag,
+        onDragEnd: this.handleThumbYDragEnd,
         axis: AXIS_DIRECTION.Y
       } as ScrollbarThumbProps;
 
@@ -946,7 +946,7 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
         style: styles.thumbX,
         elementRef: this.elementRefThumbX,
         onDrag: this.handleThumbXDrag,
-        onDragEnd: this.handleThumbXDrag,
+        onDragEnd: this.handleThumbXDragEnd,
         axis: AXIS_DIRECTION.X
       } as ScrollbarThumbProps;
 
@@ -1259,6 +1259,22 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       thumbSize,
       offset
     );
+  };
+
+  private handleThumbYDragEnd = (data: DraggableData): void => {
+    const { thumbYProps } = this.props;
+    if (thumbYProps && thumbYProps.onDragEnd) {
+      thumbYProps.onDragEnd(data);
+    }
+    this.handleThumbYDrag(data);
+  };
+
+  private handleThumbXDragEnd = (data: DraggableData): void => {
+    const { thumbXProps } = this.props;
+    if (thumbXProps && thumbXProps.onDragEnd) {
+      thumbXProps.onDragEnd(data);
+    }
+    this.handleThumbXDrag(data);
   };
 
   private handleThumbYDrag = (data: DraggableData): void => {


### PR DESCRIPTION
# Description

Currently if developer set onDragEnd on thumbXProps or thumbYProps, it will be overrided!

## Use case
Developer want to add control buttons (Scroll by pressing button) to trackbar and control their style base on drag event

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] _Bug fix_ (non-breaking change which fixes an issue)
- [x] _New feature_ (non-breaking change which adds functionality)
- [ ] **_Breaking change_** (fix or feature that would cause existing functionality to not work as before)

# Checklist

<!-- Check all the items your PR meets. In general - only coverage item is allowed not to be checked. -->

- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Update/add the documentation
- [ ] Write tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage

<!-- If you can't check all the checkboxes - create a Draft PR and get back to it when you will be able to put some marks in list. -->
