### PR TITLE
Fix wrong `trackXVisible` and `trackYVisible` values passed to callback `onUpdate`

### DIFF
--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -565,8 +565,8 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       scrollState.scrollYPossible = !scrollState.scrollYBlocked && scrollState.scrollHeight > scrollState.clientHeight;
       scrollState.scrollXPossible = !scrollState.scrollXBlocked && scrollState.scrollWidth > scrollState.clientWidth;
 
-      scrollState.trackYVisible = props.permanentTracks! || props.permanentTrackY! || scrollState.scrollYPossible;
-      scrollState.trackXVisible = props.permanentTracks! || props.permanentTrackX! || scrollState.scrollXPossible;
+      scrollState.trackYVisible = props.permanentTracks || props.permanentTrackY || scrollState.scrollYPossible;
+      scrollState.trackXVisible = props.permanentTracks || props.permanentTrackX || scrollState.scrollXPossible;
     }
 
     if (this.contentElement) {

--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -565,8 +565,8 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
       scrollState.scrollYPossible = !scrollState.scrollYBlocked && scrollState.scrollHeight > scrollState.clientHeight;
       scrollState.scrollXPossible = !scrollState.scrollXBlocked && scrollState.scrollWidth > scrollState.clientWidth;
 
-      scrollState.trackYVisible = scrollState.scrollYPossible || props.permanentTracks! || props.permanentTrackY!;
-      scrollState.trackXVisible = scrollState.scrollXPossible || props.permanentTracks! || props.permanentTrackX!;
+      scrollState.trackYVisible = props.permanentTracks! || props.permanentTrackY! || scrollState.scrollYPossible;
+      scrollState.trackXVisible = props.permanentTracks! || props.permanentTrackX! || scrollState.scrollXPossible;
     }
 
     if (this.contentElement) {


### PR DESCRIPTION
# Description

If `permanentTrackX` and `permanentTrackY` props are not passed to Scrollbar, the values of `trackXVisible` and `trackYVisible` will be `undefined` while forcedly getting scroll state. Fix this to make them to be `false` value.

**EDIT**:

When event `onUpdate` is called, the properties `trackXVisible` and `trackYVisible` of argument `scrollValues` would be `undefined` if props `permanentTrackX` and `permanentTrackY` are not passed to `Scrollbar`.

Changed the assignment statement of `scrollState.trackXVisible` and `scrollState.trackYVisible` to fix this problem.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] _Bug fix_ (non-breaking change which fixes an issue)
