### PR TITLE
Trigger Re-Render when Scrollability Changes and PermanentTrack is Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test": "cross-env NODE_ENV=production karma start",
     "preversion": "npm run format && npm run build",
     "prepublishOnly": "npm run format && npm run test && npm run build",
-    "prepare": "npm run format && npm run test && npm run build",
+    "prepare": "npm run build",
     "push-codacy-coverage": "cat ./coverage/lcov.info | codacy-coverage"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test": "cross-env NODE_ENV=production karma start",
     "preversion": "npm run format && npm run build",
     "prepublishOnly": "npm run format && npm run test && npm run build",
+    "prepare": "npm run format && npm run test && npm run build",
     "push-codacy-coverage": "cat ./coverage/lcov.info | codacy-coverage"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "test": "cross-env NODE_ENV=production karma start",
     "preversion": "npm run format && npm run build",
     "prepublishOnly": "npm run format && npm run test && npm run build",
-    "prepare": "npm run build",
     "push-codacy-coverage": "cat ./coverage/lcov.info | codacy-coverage"
   },
   "prettier": {

--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -746,6 +746,12 @@ export default class Scrollbar extends React.Component<ScrollbarProps, Scrollbar
 
     this.scrollValues = scrollState;
 
+    // Check if the status of whether scrolling is possible has changed, and if it has force a re-render. This handles
+    // the condition of permanentTracks enabled because otherwise we're depending on trackVisibility changing to trigger a re-render.
+    if (bitmask & (1 << 8) || bitmask & (1 << 9)) {
+      this.forceUpdate();
+    }
+
     if (!props.native && bitmask & (1 << 15)) {
       util.getScrollbarWidth(true);
       this.forceUpdate();


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There is an edge case that exists where if permanentTrackY/X is enabled and the scrollability of the child content changes, a re-render is not triggered and therefore the component remains in its previous scrollable state. This happens because the primary place where a re-render is triggered in the update method is from updating the state only when scrollbar visibility has changed. This obviously never happens when permanentTrackX/Y is enabled. This PR adds a check for if the scrollability has changed and forced a re-render if it has.

## Use case

<!-- What is the final use case? Describe it with words, code or even sandboxes (4ex: [codesandbox.io](https://codesandbox.io)) -->

This addresses issue #171 and can be replicated in https://codesandbox.io/s/sharp-engelbart-fnc2e?file=/src/App.js. It is applicable in situations when the scrollability of the underlying content changes, such as with dynamic content.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] _Bug fix_ (non-breaking change which fixes an issue)

# Checklist

<!-- Check all the items your PR meets. In general - only coverage item is allowed not to be checked. -->

- [X ] Perform a code self-review
- [X ] Comment the code, particularly in hard-to-understand areas
- [ ] Update/add the documentation - since this is a bugfix I don't think this is necessary
- [ ] Write tests
- [ ] Ensure the test suite passes (`yarn test`) - tests were already not passing. this did not cause any additional tests to fail.
- [ ] Provide 100% tests coverage - see above
