### PR TITLE
fix: explicit children typing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,9 @@ export type ElementPropsWithElementRef<T = HTMLDivElement> = React.HTMLProps<T> 
   elementRef?: ElementRef<T>;
 };
 
-export type ElementRenderer<T = HTMLDivElement> = React.FC<ElementPropsWithElementRef<T>>;
+export type ElementRenderer<T = HTMLDivElement> = React.FC<
+  React.PropsWithChildren<ElementPropsWithElementRef<T>>
+>;
 
 export type ElementPropsWithElementRefAndRenderer<T = HTMLDivElement> = React.HTMLProps<T> & {
   elementRef?: ElementRef<T>;


### PR DESCRIPTION
Types fix for react 18, that requires explicit childern definition in props
