### PR TITLE
Stop requiring style-src 'unsafe-inline' CSP

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -218,6 +218,15 @@ interface GetScrollbarWidthFN {
   (force?: boolean): number | undefined;
 }
 
+const setWidthDetectorStyle = (el: HTMLDivElement): void => {
+  el.style.position = 'absolute';
+  el.style.width = '100px';
+  el.style.height = '100px';
+  el.style.top = '-999px';
+  el.style.left = '-999px';
+  el.style.overflow = 'scroll';
+}
+
 /**
  * @description Returns scrollbar width specific for current environment. Can return undefined if DOM is not ready yet.
  */
@@ -233,10 +242,7 @@ export const getScrollbarWidth: GetScrollbarWidthFN = (force = false): number | 
   }
 
   const el = doc.createElement('div');
-  el.setAttribute(
-    'style',
-    'position:absolute;width:100px;height:100px;top:-999px;left:-999px;overflow:scroll;'
-  );
+  setWidthDetectorStyle(el);
 
   doc.body.append(el);
 
@@ -277,11 +283,11 @@ export const shouldReverseRtlScroll: ShouldReverseRtlScroll = (force = false): b
 
   el.append(child);
 
-  el.setAttribute(
-    'style',
-    'position:absolute;width:100px;height:100px;top:-999px;left:-999px;overflow:scroll;direction:rtl'
-  );
-  child.setAttribute('style', 'width:1000px;height:1000px');
+  setWidthDetectorStyle(el);
+  el.style.direction = 'rtl';
+
+  child.style.width = '1000px';
+  child.style.left = '1000px';
 
   doc.body.append(el);
 


### PR DESCRIPTION
# Description

Addresses #469.

Setting the `style` attribute on an element violates stricter CSP and requires a policy of `style-src 'unsafe-inline'`. Setting each style in the style property of the element resolves this issue.

## Use case

A safe application with a strict CSP. See https://codesandbox.io/s/autumn-fast-n5p48h?file=/public/index.html and #469 for more details.

## Type of change

- [x] _Bug fix_ (non-breaking change which fixes an issue)

# Checklist

<!-- Check all the items your PR meets. In general - only coverage item is allowed not to be checked. -->

- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Update/add the documentation
- [x] Write tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage

